### PR TITLE
Use correct repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Pretty ESLint formatter",
   "license": "MIT",
-  "repository": "sindresorhus/eslint-formatter-xo",
+  "repository": "sindresorhus/eslint-formatter-pretty",
   "author": {
     "name": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",


### PR DESCRIPTION
This'll fix the broken screenshot on https://www.npmjs.com/package/eslint-formatter-pretty