### PR TITLE
Make column lines consistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "chalk": "^1.1.3",
     "log-symbols": "^1.0.2",
     "plur": "^2.1.2",
-    "string-width": "^1.0.1",
-    "text-table": "^0.2.0"
+    "string-width": "^1.0.1"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
Aligns the `message` and `ruleId` columns, as well as aligning the `:`.

Fixes #1.

It drops `text-table` as a dependency. That adds a few lines to our code, but allows us to allign across multiple sections.