### PR TITLE
use gray for rule titles

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ module.exports = function (results) {
 				x.severity === 'warning' ? logSymbols.warning : logSymbols.error,
 				padding(maxLineWidth - x.lineWidth) + chalk.dim(x.line + chalk.gray(':') + x.column),
 				padding(maxColumnWidth - x.columnWidth) + x.message,
-				padding(maxMessageWidth - x.messageWidth) + chalk.dim(x.ruleId)
+				padding(maxMessageWidth - x.messageWidth) + chalk.gray.dim(x.ruleId)
 			].join('  ');
 		}
 


### PR DESCRIPTION
Master:

<img width="417" alt="screenshot 2016-04-30 17 41 30" src="https://cloud.githubusercontent.com/assets/4082216/14938731/7b65cd96-0efb-11e6-8499-3dfe38f11c56.png">

This PR:

<img width="411" alt="screenshot 2016-04-30 17 45 13" src="https://cloud.githubusercontent.com/assets/4082216/14938733/85b10ebe-0efb-11e6-97f6-15bb9e3b7d30.png">

Screenshots are iTerm2.

It just dims the rule titles a bit. They generally are not that important.