### PR TITLE
Up arrow for repeating rule ids

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,20 +76,33 @@ module.exports = function (results) {
 	// make relative paths Cmd+click'able in iTerm
 	output += ansiEscapes.iTerm.setCwd();
 
+	var lastRuleId = null;
+
 	output += lines.map(function (x) {
 		if (x.type === 'header') {
+			lastRuleId = null;
 			// add the line number so it's Cmd+click'able in some terminals
 			// use dim & gray for terminals like iTerm that doesn't support `hidden`
 			return '  ' + chalk.underline(x.relativeFilePath + chalk.hidden.dim.gray(':' + x.firstLineCol));
 		}
 
 		if (x.type === 'message') {
+			var ruleId = x.ruleId;
+
+			if (ruleId === lastRuleId) {
+				// ruleId = '↑';
+				// ruleId = '^';
+				ruleId = '⇧';
+			}
+
+			lastRuleId = x.ruleId;
+
 			return [
 				'',
 				x.severity === 'warning' ? logSymbols.warning : logSymbols.error,
 				padding(maxLineWidth - x.lineWidth) + chalk.dim(x.line + chalk.gray(':') + x.column),
 				padding(maxColumnWidth - x.columnWidth) + x.message,
-				padding(maxMessageWidth - x.messageWidth) + chalk.gray.dim(x.ruleId)
+				padding(maxMessageWidth - x.messageWidth) + chalk.gray.dim(ruleId)
 			].join('  ');
 		}
 

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ module.exports = function (results) {
 				x.severity === 'warning' ? logSymbols.warning : logSymbols.error,
 				padding(maxLineWidth - x.lineWidth) + chalk.dim(x.line + chalk.gray(':') + x.column),
 				padding(maxColumnWidth - x.columnWidth) + x.message,
-				padding(maxMessageWidth - x.messageWidth) + chalk.dim(x.ruleId)
+				padding(maxMessageWidth - x.messageWidth) + chalk.gray.dim(x.ruleId)
 			].join('  ');
 		}
 


### PR DESCRIPTION
<img width="466" alt="screenshot 2016-04-30 17 56 35" src="https://cloud.githubusercontent.com/assets/4082216/14938824/0ab1af12-0eff-11e6-9ccf-d148ceef7156.png">

<img width="446" alt="screenshot 2016-04-30 17 56 59" src="https://cloud.githubusercontent.com/assets/4082216/14938826/0eff7fc2-0eff-11e6-9fec-42a15472edde.png">

<img width="439" alt="screenshot 2016-04-30 17 58 09" src="https://cloud.githubusercontent.com/assets/4082216/14938828/13a0c892-0eff-11e6-849d-29f75c74c19f.png">

I think I like the last one the best.

Includes the change to gray from #6, so I'll need to rebase if we merge that. This has extra comment lines that need to be deleted anyways after we decide on an arrow.