### PR TITLE
hide title position if no line numbers are provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,9 @@ module.exports = results => {
 		if (x.type === 'header') {
 			// add the line number so it's Cmd+click'able in some terminals
 			// use dim & gray for terminals like iTerm that doesn't support `hidden`
-			return '  ' + chalk.underline(x.relativeFilePath + chalk.hidden.dim.gray(`:${x.firstLineCol}`));
+			const position = showLineNumbers ? chalk.hidden.dim.gray(`:${x.firstLineCol}`) : '';
+
+			return '  ' + chalk.underline(x.relativeFilePath + position);
 		}
 
 		if (x.type === 'message') {

--- a/test/test.js
+++ b/test/test.js
@@ -8,12 +8,14 @@ import lineNumbers from './fixtures/line-numbers';
 test('output', t => {
 	const output = m(defaultFixture);
 	console.log(output);
+	t.regex(stripAnsi(output), /index\.js:8:2\n/);
 	t.regex(stripAnsi(output), /✖[ ]{3}1:1[ ]{2}AVA should be imported as test.[ ]{6}ava\/use-test/);
 });
 
 test('no line numbers', t => {
 	const output = m(noLineNumbers);
 	console.log(output);
+	t.regex(stripAnsi(output), /index\.js\n/);
 	t.regex(stripAnsi(output), /✖[ ]{2}AVA should be imported as test.[ ]{6}ava\/use-test/);
 });
 


### PR DESCRIPTION
Fixes the `undefined:undefined` bug in the header if no line numbers are provided.