### PR TITLE
Fixes line and column numbers not being sorted correctly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,14 +42,38 @@ module.exports = results => {
 
 			messages
 				.sort((a, b) => {
-					const condition = (a.fatal || a.severity === 2) && (!b.fatal || b.severity !== 2);
+					if (a.fatal === b.fatal && a.severity === b.severity) {
+						if (a.line === b.line) {
+							const isColumnFirst = a.column < b.column;
 
-					if (condition) {
-						return 1;
-					}
+							if (isColumnFirst) {
+								return -1;
+							}
 
-					if (!condition) {
-						return -1;
+							if (!isColumnFirst) {
+								return 1;
+							}
+						} else {
+							const isLineFirst = a.line < b.line;
+
+							if (isLineFirst) {
+								return -1;
+							}
+
+							if (!isLineFirst) {
+								return 1;
+							}
+						}
+					} else {
+						const isError = (a.fatal || a.severity === 2) && (!b.fatal || b.severity !== 2);
+
+						if (isError) {
+							return 1;
+						}
+
+						if (!isError) {
+							return -1;
+						}
 					}
 
 					return 0;

--- a/index.js
+++ b/index.js
@@ -44,39 +44,15 @@ module.exports = results => {
 				.sort((a, b) => {
 					if (a.fatal === b.fatal && a.severity === b.severity) {
 						if (a.line === b.line) {
-							const isColumnFirst = a.column < b.column;
-
-							if (isColumnFirst) {
-								return -1;
-							}
-
-							if (!isColumnFirst) {
-								return 1;
-							}
-						} else {
-							const isLineFirst = a.line < b.line;
-
-							if (isLineFirst) {
-								return -1;
-							}
-
-							if (!isLineFirst) {
-								return 1;
-							}
-						}
-					} else {
-						const isError = (a.fatal || a.severity === 2) && (!b.fatal || b.severity !== 2);
-
-						if (isError) {
-							return 1;
+							return a.column < b.column ? -1 : 1;
 						}
 
-						if (!isError) {
-							return -1;
-						}
+						return a.line < b.line ? -1 : 1;
+					} else if ((a.fatal || a.severity === 2) && (!b.fatal || b.severity !== 2)) {
+						return 1;
 					}
 
-					return 0;
+					return -1;
 				})
 				.forEach(x => {
 					let message = x.message;

--- a/test/fixtures/sort-by-severity-then-line-then-column.json
+++ b/test/fixtures/sort-by-severity-then-line-then-column.json
@@ -1,0 +1,63 @@
+[
+	{
+		"filePath": "/Users/sindresorhus/dev/eslint-formatter-pretty/index.js",
+		"messages": [
+			{
+				"ruleId": "no-warning-comments",
+				"severity": 1,
+				"message": "Unexpected 'todo' comment.",
+				"line": 1,
+				"column": 1,
+				"nodeType": "Line",
+				"source": "\t// TODO: fix this later"
+			},
+			{
+				"ruleId": "no-multiple-empty-lines",
+				"severity": 2,
+				"message": "More than 1 blank line not allowed.",
+				"line": 3,
+				"column": 1,
+				"nodeType": "Program",
+				"source": ""
+			},
+			{
+				"ruleId": "no-warning-comments",
+				"severity": 1,
+				"message": "Unexpected 'todo' comment.",
+				"line": 10,
+				"column": 2,
+				"nodeType": "Line",
+				"source": "\t// TODO: fix this later"
+			},
+			{
+				"ruleId": "no-multiple-empty-lines",
+				"severity": 2,
+				"message": "More than 1 blank line not allowed.",
+				"line": 30,
+				"column": 1,
+				"nodeType": "Program",
+				"source": ""
+			},
+			{
+				"ruleId": "no-unused-vars",
+				"severity": 2,
+				"message": "'i' is defined but never used.",
+				"line": 40,
+				"column": 5,
+				"nodeType": "Identifier",
+				"source": "var i, j;"
+			},
+			{
+				"ruleId": "no-unused-vars",
+				"severity": 2,
+				"message": "'j' is defined but never used.",
+				"line": 40,
+				"column": 8,
+				"nodeType": "Identifier",
+				"source": "var i, j;"
+			}
+		],
+		"errorCount": 4,
+		"warningCount": 2
+	}
+]

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,5 @@ test('sort by severity, then line number, then column', t => {
 		sanitized.indexOf('✖  40:8')
 	];
 	console.log(output);
-	t.deepEqual(indexes, indexes.slice().sort((a, b) => {
-		return a - b;
-	}));
+	t.deepEqual(indexes, indexes.slice().sort((a, b) =>  a - b ));
 });

--- a/test/test.js
+++ b/test/test.js
@@ -39,5 +39,7 @@ test('sort by severity, then line number, then column', t => {
 		sanitized.indexOf('✖  40:8')
 	];
 	console.log(output);
-	t.deepEqual(indexes, indexes.slice().sort());
+	t.deepEqual(indexes, indexes.slice().sort((a, b) => {
+		return a - b;
+	}));
 });

--- a/test/test.js
+++ b/test/test.js
@@ -39,5 +39,5 @@ test('sort by severity, then line number, then column', t => {
 		sanitized.indexOf('✖  40:8')
 	];
 	console.log(output);
-	t.deepEqual(indexes, indexes.slice(0).sort());
+	t.deepEqual(indexes, indexes.slice().sort());
 });

--- a/test/test.js
+++ b/test/test.js
@@ -39,5 +39,5 @@ test('sort by severity, then line number, then column', t => {
 		sanitized.indexOf('✖  40:8')
 	];
 	console.log(output);
-	t.deepEqual(indexes, indexes.slice().sort((a, b) =>  a - b ));
+	t.deepEqual(indexes, indexes.slice().sort((a, b) => a - b));
 });

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ import m from '../';
 import defaultFixture from './fixtures/default';
 import noLineNumbers from './fixtures/no-line-numbers';
 import lineNumbers from './fixtures/line-numbers';
+import sortOrder from './fixtures/sort-by-severity-then-line-then-column';
 
 test('output', t => {
 	const output = m(defaultFixture);
@@ -24,4 +25,19 @@ test('show line numbers', t => {
 	console.log(output);
 	t.regex(stripAnsi(output), /⚠[ ]{3}0:0[ ]{2}Unexpected todo comment.[ ]{13}no-warning-comments/);
 	t.regex(stripAnsi(output), /✖[ ]{3}1:1[ ]{2}AVA should be imported as test.[ ]{6}ava\/use-test/);
+});
+
+test('sort by severity, then line number, then column', t => {
+	const output = m(sortOrder);
+	const sanitized = stripAnsi(output);
+	const indexes = [
+		sanitized.indexOf('⚠   1:1'),
+		sanitized.indexOf('⚠  10:2'),
+		sanitized.indexOf('✖   3:1'),
+		sanitized.indexOf('✖  30:1'),
+		sanitized.indexOf('✖  40:5'),
+		sanitized.indexOf('✖  40:8')
+	];
+	console.log(output);
+	t.deepEqual(indexes, indexes.slice(0).sort());
 });


### PR DESCRIPTION
I'm not necessarily happy with the verboseness of the production code, but I felt anything more clever became unreadable. I am totally open to suggestions if you have them.

Regardless, this PR correctly sorts results by severity, then line number, then column number.

Before:

![index_js_-_eslint-formatter-pretty_-____developer_eslint-formatter-pretty_](https://cloud.githubusercontent.com/assets/446260/19139266/bc909516-8b48-11e6-8c19-f0fb108bc38b.jpg)

After:

![index_js_-_eslint-formatter-pretty_-____developer_eslint-formatter-pretty_](https://cloud.githubusercontent.com/assets/446260/19139271/c6c8602c-8b48-11e6-8057-f3e2c6efaa7f.jpg)

Fixes #21 
