### PR TITLE
Updated webpack loader example to preferred method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,10 +61,11 @@ module.exports = {
 		filename: '[name].js'
 	},
 	module: {
-		loaders: [
+		preLoaders: [
 			{
 				test: /\.js$/,
-				loader: 'eslint-loader'
+				loader: 'eslint-loader',
+				exclude: /node_modules/
 			}
 		]
 	},


### PR DESCRIPTION
[webpack-loader instructions](https://github.com/MoOx/eslint-loader#usage) recommend that `preLoader` be used to be safe. Also `node_modules` should be ignored
