### PR TITLE
Change warning totals to be displayed before error totals

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,12 +120,12 @@ module.exports = results => {
 		return '';
 	}).join('\n') + '\n\n';
 
-	if (errorCount > 0) {
-		output += '  ' + chalk.red(`${errorCount}  ${plur('error', errorCount)}`) + '\n';
-	}
-
 	if (warningCount > 0) {
 		output += '  ' + chalk.yellow(`${warningCount} ${plur('warning', warningCount)}`) + '\n';
+	}
+
+	if (errorCount > 0) {
+		output += '  ' + chalk.red(`${errorCount}  ${plur('error', errorCount)}`) + '\n';
 	}
 
 	return (errorCount + warningCount) > 0 ? output : '';

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ test('show line numbers', t => {
 	t.regex(stripAnsi(output), /✖[ ]{3}1:1[ ]{2}AVA should be imported as test.[ ]{6}ava\/use-test/);
 });
 
-test('sort by severity, then line number, then column', t => {
+test('sort by severity, then line number, then column number', t => {
 	const output = m(sortOrder);
 	const sanitized = stripAnsi(output);
 	const indexes = [
@@ -37,6 +37,17 @@ test('sort by severity, then line number, then column', t => {
 		sanitized.indexOf('✖  30:1'),
 		sanitized.indexOf('✖  40:5'),
 		sanitized.indexOf('✖  40:8')
+	];
+	console.log(output);
+	t.deepEqual(indexes, indexes.slice().sort((a, b) => a - b));
+});
+
+test('display warning total before error total', t => {
+	const output = m(sortOrder);
+	const sanitized = stripAnsi(output);
+	const indexes = [
+		sanitized.indexOf('2 warnings'),
+		sanitized.indexOf('4  errors')
 	];
 	console.log(output);
 	t.deepEqual(indexes, indexes.slice().sort((a, b) => a - b));


### PR DESCRIPTION
I noticed this while working on #22 and thought I'd make a separate PR for it. It's not critical or anything. In fact, it could just be my own preference, so feel free to accept or decline. No hard feelings either way. 😄 

Since severities are now grouped and warnings are seen first in the output (see #12 for more information), I thought it made sense to list the warning totals before the error totals.

Before:

![index_js_-_eslint-formatter-pretty_-____developer_eslint-formatter-pretty_](https://cloud.githubusercontent.com/assets/446260/19214568/6a9a10c4-8d4c-11e6-8405-281e7aae7eaa.jpg)


After:

![test_js_-_eslint-formatter-pretty_-____developer_eslint-formatter-pretty_](https://cloud.githubusercontent.com/assets/446260/19214563/577886f6-8d4c-11e6-93fd-c56e8838fe09.jpg)

