### PR TITLE
Sort reports with least number of required fixes displayed last

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,18 @@ module.exports = results => {
 	let showLineNumbers = false;
 
 	results
-		.sort((a, b) => a.errorCount - b.errorCount)
+		.sort((a, b) => {
+			if (a.errorCount === b.errorCount) {
+				return b.warningCount - a.warningCount;
+			}
+			if (a.errorCount === 0) {
+				return -1;
+			}
+			if (b.errorCount === 0) {
+				return 1;
+			}
+			return b.errorCount - a.errorCount;
+		})
 		.forEach(result => {
 			const {messages, filePath} = result;
 

--- a/index.js
+++ b/index.js
@@ -22,12 +22,15 @@ module.exports = results => {
 			if (a.errorCount === b.errorCount) {
 				return b.warningCount - a.warningCount;
 			}
+
 			if (a.errorCount === 0) {
 				return -1;
 			}
+
 			if (b.errorCount === 0) {
 				return 1;
 			}
+
 			return b.errorCount - a.errorCount;
 		})
 		.forEach(result => {

--- a/test/fixtures/messages.json
+++ b/test/fixtures/messages.json
@@ -1,0 +1,65 @@
+[
+	{
+		"ruleId": "no-warning-comments",
+		"severity": 1,
+		"message": "Unexpected 'todo' comment.",
+		"line": 1,
+		"column": 1,
+		"nodeType": "Line",
+		"source": "\t// TODO: fix this later"
+	},
+	{
+		"ruleId": "no-multiple-empty-lines",
+		"severity": 2,
+		"message": "More than 1 blank line not allowed.",
+		"line": 3,
+		"column": 1,
+		"nodeType": "Program",
+		"source": ""
+	},
+	{
+		"ruleId": "no-warning-comments",
+		"severity": 1,
+		"message": "Unexpected 'todo' comment.",
+		"line": 10,
+		"column": 2,
+		"nodeType": "Line",
+		"source": "\t// TODO: fix this later"
+	},
+	{
+		"ruleId": "no-warning-comments",
+		"severity": 1,
+		"message": "Unexpected 'todo' comment.",
+		"line": 15,
+		"column": 2,
+		"nodeType": "Line",
+		"source": "\t// TODO: fix this later"
+	},
+	{
+		"ruleId": "no-multiple-empty-lines",
+		"severity": 2,
+		"message": "More than 1 blank line not allowed.",
+		"line": 30,
+		"column": 1,
+		"nodeType": "Program",
+		"source": ""
+	},
+	{
+		"ruleId": "no-unused-vars",
+		"severity": 2,
+		"message": "'i' is defined but never used.",
+		"line": 40,
+		"column": 5,
+		"nodeType": "Identifier",
+		"source": "var i, j;"
+	},
+	{
+		"ruleId": "no-unused-vars",
+		"severity": 2,
+		"message": "'j' is defined but never used.",
+		"line": 40,
+		"column": 8,
+		"nodeType": "Identifier",
+		"source": "var i, j;"
+	}
+]


### PR DESCRIPTION
The idea is that you want the lowest hanging fruit displayed at
the bottom, so it is immediately visible in your terminal.

Files with only warnings (i.e. zero errors) are still displayed
at the top, but otherwise, fewer errors are displayed near the bottom.

Fixes: xojs/xo/issues/361