### PR TITLE
Make file heading link to the first error

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,11 +33,13 @@ module.exports = results => {
 				lines.push({type: 'separator'});
 			}
 
+			const firstErrorOrWarning = messages.find(({severity}) => severity === 2) || messages[0];
+
 			lines.push({
 				type: 'header',
 				filePath,
 				relativeFilePath: path.relative('.', filePath),
-				firstLineCol: messages[0].line + ':' + messages[0].column
+				firstLineCol: firstErrorOrWarning.line + ':' + firstErrorOrWarning.column
 			});
 
 			messages

--- a/test/test.js
+++ b/test/test.js
@@ -20,8 +20,22 @@ test('output', t => {
 	disableHyperlinks();
 	const output = m(defaultFixture);
 	console.log(output);
-	t.regex(stripAnsi(output), /index\.js:8:2\n/);
+	t.regex(stripAnsi(output), /index\.js:18:2\n/);
 	t.regex(stripAnsi(output), /✖[ ]{3}1:1[ ]{2}AVA should be imported as test.[ ]{6}ava\/use-test/);
+});
+
+test('file heading links to the first error line', t => {
+	disableHyperlinks();
+	const output = m(defaultFixture);
+	console.log(output);
+	t.regex(stripAnsi(output), /index\.js:18:2\n/);
+});
+
+test('file heading links to the first warning line, if no errors in the file', t => {
+	disableHyperlinks();
+	const output = m(defaultFixture);
+	console.log(output);
+	t.regex(stripAnsi(output), /test\.js:1:1\n/);
 });
 
 test('no line numbers', t => {

--- a/test/test.js
+++ b/test/test.js
@@ -31,7 +31,7 @@ test('file heading links to the first error line', t => {
 	t.regex(stripAnsi(output), /index\.js:18:2\n/);
 });
 
-test('file heading links to the first warning line, if no errors in the file', t => {
+test('file heading links to the first warning line if no errors in the file', t => {
 	disableHyperlinks();
 	const output = m(defaultFixture);
 	console.log(output);


### PR DESCRIPTION
Previously, we linked to the first message, which was often a warning, not an error.
Instead, link to the first higher-severity error (if available).

Fixes: #37