### PR TITLE
Unpack todo/warning comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const stringWidth = require('string-width');
 const ansiEscapes = require('ansi-escapes');
 const {supportsHyperlink} = require('supports-hyperlinks');
 const getRuleUrl = require('eslint-rule-docs');
-const termSize = require('term-size');
 const cliTruncate = require('cli-truncate');
 
 const formatter = results => {
@@ -22,7 +21,7 @@ const formatter = results => {
 	let showLineNumbers = false;
 
 	// Allow terminalWidth to be easily manipulated by tests.
-	const terminalWidth = formatter.terminalWidth || termSize().columns;
+	const terminalWidth = formatter.terminalWidth || (process.stdout && process.stdout.getWindowsSize().width) || 80;
 
 	results
 		.sort((a, b) => {
@@ -81,7 +80,7 @@ const formatter = results => {
 					let {message} = x;
 					let isWarningComment = false;
 
-					if (x.ruleId === 'no-warning-comments') {
+					if (x.ruleId === 'no-warning-comments' && x.source) {
 						isWarningComment = true;
 						message = x.source.trim().replace(/^\/\/\s*|\/\*\s*/, '');
 					}

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
 	"dependencies": {
 		"ansi-escapes": "^3.0.0",
 		"chalk": "^2.1.0",
+		"cli-truncate": "^1.1.0",
 		"eslint-rule-docs": "^1.1.5",
 		"log-symbols": "^2.0.0",
 		"plur": "^3.0.1",
 		"string-width": "^2.0.0",
-		"supports-hyperlinks": "^1.0.1"
+		"supports-hyperlinks": "^1.0.1",
+		"term-size": "^1.2.0"
 	},
 	"devDependencies": {
 		"ava": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
 		"log-symbols": "^2.0.0",
 		"plur": "^3.0.1",
 		"string-width": "^2.0.0",
-		"supports-hyperlinks": "^1.0.1",
-		"term-size": "^1.2.0"
+		"supports-hyperlinks": "^1.0.1"
 	},
 	"devDependencies": {
 		"ava": "^0.25.0",

--- a/test/fixtures/line-numbers-no-source.json
+++ b/test/fixtures/line-numbers-no-source.json
@@ -1,0 +1,38 @@
+[
+	{
+		"filePath": "/Users/sindresorhus/dev/eslint-formatter-pretty/index.js",
+		"messages": [
+			{
+				"ruleId": "no-warning-comments",
+				"severity": 1,
+				"message": "Unexpected 'todo' comment.",
+				"nodeType": "Line"
+			},
+			{
+				"ruleId": "no-multiple-empty-lines",
+				"severity": 2,
+				"message": "More than 1 blank line not allowed.",
+				"line": 18,
+				"column": 2,
+				"nodeType": "Program"
+			}
+		],
+		"errorCount": 1,
+		"warningCount": 1
+	},
+	{
+		"filePath": "/Users/sindresorhus/dev/eslint-formatter-pretty/test.js",
+		"messages": [
+			{
+				"ruleId": "ava/use-test",
+				"severity": 2,
+				"message": "AVA should be imported as `test`.",
+				"line": 1,
+				"column": 1,
+				"nodeType": "ImportDeclaration"
+			}
+		],
+		"errorCount": 1,
+		"warningCount": 0
+	}
+]

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,7 @@ import m from '..';
 import defaultFixture from './fixtures/default';
 import noLineNumbers from './fixtures/no-line-numbers';
 import lineNumbers from './fixtures/line-numbers';
+import lineNumbersNoSource from './fixtures/line-numbers-no-source';
 import sortOrder from './fixtures/sort-by-severity-then-line-then-column';
 import messages from './fixtures/messages';
 
@@ -117,6 +118,14 @@ test('drop the ruleId before truncating warning comments"', t => {
 	console.log(output);
 	t.regex(stripAnsi(output), /⚠[ ]{3}0:0[ ]{2}TODO: fix this later/);
 	t.regex(stripAnsi(output), /✖[ ]{3}1:1[ ]{2}AVA should be imp…[ ]{2}ava\/use-test/);
+});
+
+test('gracefully handle missing source for warning comments', t => {
+	disableHyperlinks();
+	const output = m(lineNumbersNoSource);
+	console.log(output);
+	t.regex(stripAnsi(output), /⚠[ ]{3}0:0[ ]{2}Unexpected todo comment.[ ]{13}no-warning-comments/);
+	t.regex(stripAnsi(output), /✖[ ]{3}1:1[ ]{2}AVA should be imported as test.[ ]{6}ava\/use-test/);
 });
 
 test('files will be sorted with least errors at the bottom, but zero errors at the top', t => {

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,10 @@ const disableHyperlinks = () => {
 	process.env.FORCE_HYPERLINK = '0';
 };
 
+test.beforeEach(() => {
+	m.terminalWidth = 150;
+});
+
 test('output', t => {
 	disableHyperlinks();
 	const output = m(defaultFixture);
@@ -58,7 +62,7 @@ test('show line numbers', t => {
 	disableHyperlinks();
 	const output = m(lineNumbers);
 	console.log(output);
-	t.regex(stripAnsi(output), /⚠[ ]{3}0:0[ ]{2}Unexpected todo comment.[ ]{13}no-warning-comments/);
+	t.regex(stripAnsi(output), /⚠[ ]{3}0:0[ ]{2}TODO: fix this later[ ]{17}no-warning-comments/);
 	t.regex(stripAnsi(output), /✖[ ]{3}1:1[ ]{2}AVA should be imported as test.[ ]{6}ava\/use-test/);
 });
 
@@ -95,6 +99,24 @@ test('display warning total before error total', t => {
 	];
 	console.log(output);
 	t.deepEqual(indexes, indexes.slice().sort((a, b) => a - b));
+});
+
+test('long messages will be truncated', t => {
+	disableHyperlinks();
+	m.terminalWidth = 56;
+	const output = m(lineNumbers);
+	console.log(output);
+	t.regex(stripAnsi(output), /⚠[ ]{3}0:0[ ]{2}TODO: fix this later[ ]{2}no-warning-comments/);
+	t.regex(stripAnsi(output), /✖[ ]{3}1:1[ ]{2}AVA should be impor…[ ]{2}ava\/use-test/);
+});
+
+test('drop the ruleId before truncating warning comments"', t => {
+	disableHyperlinks();
+	m.terminalWidth = 54;
+	const output = m(lineNumbers);
+	console.log(output);
+	t.regex(stripAnsi(output), /⚠[ ]{3}0:0[ ]{2}TODO: fix this later/);
+	t.regex(stripAnsi(output), /✖[ ]{3}1:1[ ]{2}AVA should be imp…[ ]{2}ava\/use-test/);
 });
 
 test('files will be sorted with least errors at the bottom, but zero errors at the top', t => {


### PR DESCRIPTION
Show the warning comments right in the terminal.

Also, will truncate all messages now based on terminal width.
For unpacked warning comments, will drop the ruleId before truncating.

Fixes: #27 