### PR TITLE
Require ansi-escape ^3.1.0 for link method

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"validate"
 	],
 	"dependencies": {
-		"ansi-escapes": "^3.0.0",
+		"ansi-escapes": "^3.1.0",
 		"chalk": "^2.1.0",
 		"eslint-rule-docs": "^1.1.5",
 		"log-symbols": "^2.0.0",


### PR DESCRIPTION
Having the following issue with xo 0.24.0:

```
TypeError: ansiEscapes.link is not a function
    at lines.map.x (/Users/tusbar/dev/tusbar/plunger/node_modules/eslint-formatter-pretty/index.js:113:54)
    at Array.map (<anonymous>)
    at module.exports.results (/Users/tusbar/dev/tusbar/plunger/node_modules/eslint-formatter-pretty/index.js:97:18)
    at log (/Users/tusbar/dev/tusbar/plunger/node_modules/xo/cli-main.js:138:23)
    at xo.lintFiles.then.report (/Users/tusbar/dev/tusbar/plunger/node_modules/xo/cli-main.js:183:3)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```