### PR TITLE
Use the `rulesMeta` property to get docs URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const ansiEscapes = require('ansi-escapes');
 const {supportsHyperlink} = require('supports-hyperlinks');
 const getRuleDocs = require('eslint-rule-docs');
 
-module.exports = results => {
+module.exports = (results, data) => {
 	const lines = [];
 	let errorCount = 0;
 	let warningCount = 0;
@@ -122,8 +122,10 @@ module.exports = results => {
 		if (x.type === 'message') {
 			let ruleUrl;
 			try {
+				ruleUrl = data.rulesMeta[x.ruleId].docs.url;
+			} catch (_) {
 				ruleUrl = getRuleDocs(x.ruleId).url;
-			} catch (_) {}
+			}
 
 			const line = [
 				'',

--- a/test/fixtures/data.json
+++ b/test/fixtures/data.json
@@ -1,0 +1,14 @@
+{
+    "rulesMeta": {
+        "no-warning-comments": {
+            "type": "suggestion",
+            "docs": {
+                "description": "disallow specified warning terms in comments",
+                "category": "Best Practices",
+                "recommended": false,
+                "url": "https://eslint.org/docs/rules/test/no-warning-comments"
+            },
+            "schema": []
+        }
+    }
+}

--- a/test/fixtures/data.json
+++ b/test/fixtures/data.json
@@ -1,14 +1,14 @@
 {
-    "rulesMeta": {
-        "no-warning-comments": {
-            "type": "suggestion",
-            "docs": {
-                "description": "disallow specified warning terms in comments",
-                "category": "Best Practices",
-                "recommended": false,
-                "url": "https://eslint.org/docs/rules/test/no-warning-comments"
-            },
-            "schema": []
-        }
-    }
+	"rulesMeta": {
+		"no-warning-comments": {
+			"type": "suggestion",
+			"docs": {
+				"description": "disallow specified warning terms in comments",
+				"category": "Best Practices",
+				"recommended": false,
+				"url": "https://eslint.org/docs/rules/test/no-warning-comments"
+			},
+			"schema": []
+		}
+	}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2,12 +2,13 @@ import test from 'ava';
 import stripAnsi from 'strip-ansi';
 import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
-import m from '..';
 import defaultFixture from './fixtures/default';
 import noLineNumbers from './fixtures/no-line-numbers';
 import lineNumbers from './fixtures/line-numbers';
 import sortOrder from './fixtures/sort-by-severity-then-line-then-column';
 import messages from './fixtures/messages';
+import data from './fixtures/data';
+import m from '..';
 
 const severityFilter = desiredSeverity => ({severity}) => severity === desiredSeverity;
 
@@ -159,4 +160,11 @@ test('files with similar errorCounts will sort according to warningCounts', t =>
 	console.log(output);
 	t.is(indexes.length, reports.length);
 	t.deepEqual(indexes, indexes.slice().sort((a, b) => a - b));
+});
+
+test('use the `rulesMeta` property to get docs URL', t => {
+	enableHyperlinks();
+	const output = m(defaultFixture, data);
+	console.log(output);
+	t.true(output.includes(ansiEscapes.link(chalk.dim('no-warning-comments'), 'https://eslint.org/docs/rules/test/no-warning-comments')));
 });


### PR DESCRIPTION
Fixes #42 

<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#42: Use the `rulesMeta ` property to get docs URL](https://issuehunt.io/repos/56529985/issues/42)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->