### PR TITLE
Fix regression when a rule has no docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,10 +121,13 @@ module.exports = (results, data) => {
 
 		if (x.type === 'message') {
 			let ruleUrl;
+
 			try {
 				ruleUrl = data.rulesMeta[x.ruleId].docs.url;
 			} catch (_) {
-				ruleUrl = getRuleDocs(x.ruleId).url;
+				try {
+					ruleUrl = getRuleDocs(x.ruleId).url;
+				} catch (_) {}
 			}
 
 			const line = [

--- a/test/fixtures/default.json
+++ b/test/fixtures/default.json
@@ -55,5 +55,21 @@
 		],
 		"errorCount": 0,
 		"warningCount": 1
+	},
+	{
+		"filePath": "/Users/sindresorhus/dev/eslint-formatter-pretty/foo.js",
+		"messages": [
+			{
+				"ruleId": "@typescript-eslint/no-unused-vars",
+				"severity": 1,
+				"message": "Unexpected 'todo' comment.",
+				"line": 8,
+				"column": 2,
+				"nodeType": "Line",
+				"source": "\t// TODO: fix this later"
+			}
+		],
+		"errorCount": 0,
+		"warningCount": 1
 	}
 ]

--- a/test/test.js
+++ b/test/test.js
@@ -168,3 +168,10 @@ test('use the `rulesMeta` property to get docs URL', t => {
 	console.log(output);
 	t.true(output.includes(ansiEscapes.link(chalk.dim('no-warning-comments'), 'https://eslint.org/docs/rules/test/no-warning-comments')));
 });
+
+test('doesn\'t throw errors when rule docs aren\'t found', t => {
+	enableHyperlinks();
+	const output = eslintFormatterPretty(defaultFixture, data);
+	console.log(output);
+	t.true(output.includes('@typescript-eslint/no-unused-vars'));
+});


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/sindresorhus/eslint-formatter-pretty/pull/48/files

Previously rules without docs would produce an error that was ignored:

```js
try {
  ruleUrl = getRuleDocs(x.ruleId).url;
} catch (_) {}
```

this was changed to

```js
try {
  ruleUrl = data.rulesMeta[x.ruleId].docs.url;
} catch (_) {
  ruleUrl = getRuleDocs(x.ruleId).url;
}
```

(notice that the error is not longer caught)

My change matches the original behavior and catches the error

```js
try {
	ruleUrl = data.rulesMeta[x.ruleId].docs.url;
} catch (_) {
	try {
		ruleUrl = getRuleDocs(x.ruleId).url;
	} catch (_) {}
}
```