### PR TITLE
Require Node.js 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '14'
   - '12'
   - '10'
-  - '8'

--- a/index.js
+++ b/index.js
@@ -124,10 +124,10 @@ module.exports = (results, data) => {
 
 			try {
 				ruleUrl = data.rulesMeta[x.ruleId].docs.url;
-			} catch (_) {
+			} catch {
 				try {
 					ruleUrl = getRuleDocs(x.ruleId).url;
-				} catch (_) {}
+				} catch {}
 			}
 
 			const line = [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -28,17 +28,17 @@
 	],
 	"dependencies": {
 		"ansi-escapes": "^4.2.1",
-		"chalk": "^3.0.0",
+		"chalk": "^4.1.0",
 		"eslint-rule-docs": "^1.1.5",
-		"log-symbols": "^3.0.0",
-		"plur": "^3.0.1",
+		"log-symbols": "^4.0.0",
+		"plur": "^4.0.0",
 		"string-width": "^4.2.0",
 		"supports-hyperlinks": "^2.0.0"
 	},
 	"devDependencies": {
-		"ava": "^1.4.1",
+		"ava": "^2.4.0",
 		"strip-ansi": "^6.0.0",
-		"xo": "^0.25.3"
+		"xo": "^0.32.0"
 	},
 	"ava": {
 		"serial": true

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+/* eslint "ava/no-import-test-files": "off" */
 import test from 'ava';
 import stripAnsi from 'strip-ansi';
 import ansiEscapes from 'ansi-escapes';
@@ -10,10 +11,8 @@ import messages from './fixtures/messages.json';
 import data from './fixtures/data.json';
 import eslintFormatterPretty from '..';
 
-const severityFilter = desiredSeverity => ({severity}) => severity === desiredSeverity;
-
 const fakeMessages = (desiredSeverity, desiredCount) => {
-	const ofDesiredSeverity = messages.filter(severityFilter(desiredSeverity));
+	const ofDesiredSeverity = messages.filter(({severity}) => severity === desiredSeverity);
 
 	if (ofDesiredSeverity.length < desiredCount) {
 		throw new Error(
@@ -44,7 +43,7 @@ test('output', t => {
 	const output = eslintFormatterPretty(defaultFixture);
 	console.log(output);
 	t.regex(stripAnsi(output), /index\.js:18:2\n/);
-	t.regex(stripAnsi(output), /✖[ ]{3}1:1[ ]{2}AVA should be imported as test.[ ]{6}ava\/use-test/);
+	t.regex(stripAnsi(output), /✖ {3}1:1 {2}AVA should be imported as test. {6}ava\/use-test/);
 });
 
 test('file heading links to the first error line', t => {
@@ -66,15 +65,15 @@ test('no line numbers', t => {
 	const output = eslintFormatterPretty(noLineNumbers);
 	console.log(output);
 	t.regex(stripAnsi(output), /index\.js\n/);
-	t.regex(stripAnsi(output), /✖[ ]{2}AVA should be imported as test.[ ]{6}ava\/use-test/);
+	t.regex(stripAnsi(output), /✖ {2}AVA should be imported as test. {6}ava\/use-test/);
 });
 
 test('show line numbers', t => {
 	disableHyperlinks();
 	const output = eslintFormatterPretty(lineNumbers);
 	console.log(output);
-	t.regex(stripAnsi(output), /⚠[ ]{3}0:0[ ]{2}Unexpected todo comment.[ ]{13}no-warning-comments/);
-	t.regex(stripAnsi(output), /✖[ ]{3}1:1[ ]{2}AVA should be imported as test.[ ]{6}ava\/use-test/);
+	t.regex(stripAnsi(output), /⚠ {3}0:0 {2}Unexpected todo comment. {13}no-warning-comments/);
+	t.regex(stripAnsi(output), /✖ {3}1:1 {2}AVA should be imported as test. {6}ava\/use-test/);
 });
 
 test('link rules to documentation when terminal supports links', t => {


### PR DESCRIPTION
First commit updates all but `ava`, deals with changes required by updated `xo`.  I updated `ava` in a separate commit as I'm not sure if converting the test to CJS is preferred or if you want something else done to enable ESM testing with the current version of ava.

I think requiring Node.js 10 is the only breaking change.