### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,12 +3,12 @@ import type {ESLint, Linter} from 'eslint';
 export = formatterPretty;
 
 /**
- * Pretty formatter for [ESLint](https://eslint.org).
- *
- * @param results - Lint result for the individual files.
- * @param data - Extended information related to the analysis results.
- * @returns The formatted output.
- */
+Pretty formatter for [ESLint](https://eslint.org).
+
+@param results - Lint result for the individual files.
+@param data - Extended information related to the analysis results.
+@returns The formatted output.
+*/
 declare function formatterPretty(
 	results: readonly formatterPretty.LintResult[],
 	data?: ESLint.LintResultData

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,35 @@
+import type {ESLint, Linter} from 'eslint';
+
+export = formatterPretty;
+
+/**
+ * Pretty formatter for [ESLint](https://eslint.org).
+ *
+ * @param results - Lint result for the individual files.
+ * @param data - Extended information related to the analysis results.
+ * @returns The formatted output.
+ */
+declare function formatterPretty(
+	results: readonly formatterPretty.LintResult[],
+	data?: ESLint.LintResultData
+): string;
+
+declare namespace formatterPretty {
+	interface LintResult {
+		readonly filePath: string;
+		readonly errorCount: number;
+		readonly warningCount: number;
+		readonly messages: readonly LintMessage[];
+	}
+
+	type Severity = Linter.Severity | 'warning' | 'error';
+
+	interface LintMessage {
+		readonly severity: Severity;
+		readonly fatal?: boolean;
+		readonly line?: number;
+		readonly column?: number;
+		readonly message: string;
+		readonly ruleId?: string | null;
+	}
+}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,50 @@
+import type {ESLint} from 'eslint';
+import {expectType} from 'tsd';
+import formatterPretty = require('.');
+
+// Test type exports
+type LintResult = formatterPretty.LintResult;
+type LintMessage = formatterPretty.LintMessage;
+type Severity = formatterPretty.Severity;
+
+// Test LintResult interface members
+declare const lintResult: LintResult;
+expectType<string>(lintResult.filePath);
+expectType<number>(lintResult.errorCount);
+expectType<number>(lintResult.warningCount);
+expectType<readonly LintMessage[]>(lintResult.messages);
+
+// Test LintMessage interface members
+const lintMessage = lintResult.messages[0];
+expectType<Severity>(lintMessage.severity);
+expectType<string>(lintMessage.message);
+expectType<boolean | undefined>(lintMessage.fatal);
+expectType<number | undefined>(lintMessage.line);
+expectType<number | undefined>(lintMessage.column);
+expectType<string | null | undefined>(lintMessage.ruleId);
+
+// Test formatterPretty()
+declare const lintResults: LintResult[];
+declare const eslintLintResults: ESLint.LintResult[];
+declare const lintResultData: ESLint.LintResultData;
+
+expectType<string>(formatterPretty(lintResults));
+expectType<string>(formatterPretty(eslintLintResults));
+expectType<string>(formatterPretty(eslintLintResults, lintResultData));
+
+interface PartialLintResult {
+	filePath: string;
+	errorCount: number;
+	warningCount: number;
+	messages: Array<{
+		fileName: string;
+		message: string;
+		severity: 'error' | 'warning';
+		line?: number;
+		column?: number;
+	}>;
+}
+
+declare const partialLintResults: PartialLintResult[];
+
+expectType<string>(formatterPretty(partialLintResults));

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
 		"node": ">=10"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"eslint",
@@ -28,6 +29,7 @@
 		"validate"
 	],
 	"dependencies": {
+		"@types/eslint": "^7.2.13",
 		"ansi-escapes": "^4.2.1",
 		"chalk": "^4.1.0",
 		"eslint-rule-docs": "^1.1.5",
@@ -39,6 +41,8 @@
 	"devDependencies": {
 		"ava": "^2.4.0",
 		"strip-ansi": "^6.0.0",
+		"tsd": "^0.17.0",
+		"typescript": "^4.3.2",
 		"xo": "^0.32.0"
 	},
 	"ava": {


### PR DESCRIPTION
Fixes #52

I didn't use the `ESLint.Formatter` interface to type this package to allow easier usage in other contexts than ESLint. The `ESLint.formatter` definition uses `ESLint.LintResult` type as a first parameter to the `Formatter` type. The problem is that the implementation of this module doesn't need all the fields of `LintResult` and some fields are accepted to be wider types than the ones `LintResult` specifies.

My definitions specify the interfaces as they are actually required by the implementation. I've added tests to make sure that they are still compatible with ESLint's types.