### PR TITLE
fix #60: only iTerm.Cwd when iTerm.app

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ export default function eslintFormatterPretty(results, data) {
 
 	let output = '\n';
 
-	if (process.stdout.isTTY && !process.env.CI) {
+	if (process.stdout.isTTY && !process.env.CI && process.env.TERM_PROGRAM === 'iTerm.app') {
 		// Make relative paths Command-clickable in iTerm
 		output += ansiEscapes.iTerm.setCwd();
 	}


### PR DESCRIPTION
This is my best guess for the `TERM_PROGRAM` value using https://github.com/jamestalmage/supports-hyperlinks/blob/master/index.js#L85 as reference. But I don't have macOS available to actually confirm. 