### PR TITLE
feat: improve rule id to always align to right of terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
 		"log-symbols": "^6.0.0",
 		"plur": "^5.1.0",
 		"string-width": "^7.0.0",
-		"supports-hyperlinks": "^3.0.0"
+		"supports-hyperlinks": "^3.0.0",
+		"terminal-size": "^4.0.0"
 	},
 	"devDependencies": {
 		"ava": "^5.3.1",


### PR DESCRIPTION
formatter-pretty can show a really nasty looking report if just 1 message exceeds or comes close to exceeding the width of the terminal

The solution below changes the alignment of the ruleId from:

current state: rule ids are aligned at the left most letter, and can line break in middle of the rule id. If any message exceeds the width of the terminal the rule id can end up in strange places for all errors reported usually with a few lines of separation.

PR state: rule ids are always right aligned. If a message exceeds the terminal width, the rule id is right aligned on the last line of the message or the following line depending on how much space it has and things look much better in many difference scenarios. 