### PR TITLE
Support VSCode built-in hyperlink function

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,9 +75,11 @@ function formatOutputLine(line, options) {
 	const {maxLineWidth, maxColumnWidth, maxMessageWidth, showLineNumbers, data} = options;
 	if (line.type === 'header') {
 		// For terminals that support hyperlinks (but not iTerm/VSCode), use file:// hyperlinks
-		if (createSupportsHyperlinks(process.stdout)
+		if (
+			createSupportsHyperlinks(process.stdout)
 			&& process.env.TERM_PROGRAM !== 'iTerm.app'
-			&& process.env.TERM_PROGRAM !== 'vscode') {
+			&& process.env.TERM_PROGRAM !== 'vscode'
+		) {
 			const fileName = chalk.underline(line.relativeFilePath);
 			const encodedPath = encodeURI(line.filePath);
 			const fileUrl = `file://${encodedPath}`;

--- a/index.js
+++ b/index.js
@@ -76,9 +76,8 @@ function formatOutputLine(line, options) {
 	if (line.type === 'header') {
 		// ITerm and VSCode should always use its native Command-click behavior with line:column
 		// Never use file:// hyperlinks for them since they can't include line:column
-		if (process.env.TERM_PROGRAM === 'iTerm.app' 
+		if (process.env.TERM_PROGRAM === 'iTerm.app'
 			|| process.env.TERM_PROGRAM === 'vscode') {
-
 			// Include hidden line:column for iTerm's Command-click
 			const fileName = chalk.underline(line.relativeFilePath);
 			const position = line.firstLineCol ? chalk.hidden.dim.gray(`:${line.firstLineCol}`) : '';

--- a/index.js
+++ b/index.js
@@ -74,25 +74,17 @@ function formatHeader(filePath, firstErrorOrWarning) {
 function formatOutputLine(line, options) {
 	const {maxLineWidth, maxColumnWidth, maxMessageWidth, showLineNumbers, data} = options;
 	if (line.type === 'header') {
-		// ITerm and VSCode should always use its native Command-click behavior with line:column
-		// Never use file:// hyperlinks for them since they can't include line:column
-		if (process.env.TERM_PROGRAM === 'iTerm.app'
-			|| process.env.TERM_PROGRAM === 'vscode') {
-			// Include hidden line:column for iTerm's Command-click
-			const fileName = chalk.underline(line.relativeFilePath);
-			const position = line.firstLineCol ? chalk.hidden.dim.gray(`:${line.firstLineCol}`) : '';
-			return '  ' + fileName + position;
-		}
-
-		// For other terminals, use file:// hyperlinks if supported
-		if (createSupportsHyperlinks(process.stdout)) {
+		// For terminals that support hyperlinks (but not iTerm/VSCode), use file:// hyperlinks
+		if (createSupportsHyperlinks(process.stdout)
+			&& process.env.TERM_PROGRAM !== 'iTerm.app'
+			&& process.env.TERM_PROGRAM !== 'vscode') {
 			const fileName = chalk.underline(line.relativeFilePath);
 			const encodedPath = encodeURI(line.filePath);
 			const fileUrl = `file://${encodedPath}`;
 			return '  ' + ansiEscapes.link(fileName, fileUrl);
 		}
 
-		// Fallback for terminals without hyperlink support
+		// Fallback for iTerm, VSCode, and other terminals: include hidden line:column for Command-click
 		const fileName = chalk.underline(line.relativeFilePath);
 		const position = line.firstLineCol ? chalk.hidden.dim.gray(`:${line.firstLineCol}`) : '';
 		return '  ' + fileName + position;

--- a/index.js
+++ b/index.js
@@ -74,9 +74,11 @@ function formatHeader(filePath, firstErrorOrWarning) {
 function formatOutputLine(line, options) {
 	const {maxLineWidth, maxColumnWidth, maxMessageWidth, showLineNumbers, data} = options;
 	if (line.type === 'header') {
-		// ITerm should always use its native Command-click behavior with line:column
-		// Never use file:// hyperlinks for iTerm since they can't include line:column
-		if (process.env.TERM_PROGRAM === 'iTerm.app') {
+		// ITerm and VSCode should always use its native Command-click behavior with line:column
+		// Never use file:// hyperlinks for them since they can't include line:column
+		if (process.env.TERM_PROGRAM === 'iTerm.app' 
+			|| process.env.TERM_PROGRAM === 'vscode') {
+
 			// Include hidden line:column for iTerm's Command-click
 			const fileName = chalk.underline(line.relativeFilePath);
 			const position = line.firstLineCol ? chalk.hidden.dim.gray(`:${line.firstLineCol}`) : '';


### PR DESCRIPTION
I'd like to propose using the iTerm workaround also for the VSCode terminal.

Maybe I am missing something, but the current implementation doesn't work for me in VSCode.

If you like, I could also simplify the condition branches, as the fallback is also identical.